### PR TITLE
Add user management operations

### DIFF
--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -150,6 +150,9 @@ paths:
       summary: Deletes a selected user
       description: >
         Deletes the user defined in path
+
+        Users holding the ADMIN permission may delete all users except other ADMINs and OWNERs.
+        OWNERs may delete all other users.
       parameters:
         - name: username
           in: path
@@ -174,6 +177,9 @@ paths:
         Updates a user's permissions.
         Permissions omitted in the request will be dropped if owned by the user previously.
         The update will reach the user when he updates his JWT token.
+
+        Users holding the ADMIN permission may change permissions of all users except other ADMINs and OWNERs.
+        OWNERs may change permission of all other users.
       parameters:
         - name: username
           in: path
@@ -925,6 +931,7 @@ components:
         ADMIN -> Allows deleting or altering other users and their permissions.
           Granting a user the admin permission will automatically grant him all other current permissions.
           Users holding the admin permission can not alter the permissions of other admins;
+        OWNER -> Allows altering permissions or deleting users holding the ADMIN or OWNER permission.
       enum:
         - skip
         - dislike
@@ -935,6 +942,7 @@ components:
         - change_volume
         - exit
         - admin
+        - owner
 
   securitySchemes:
     Token:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -146,9 +146,9 @@ paths:
           description: The user does not exist
     put:
       operationId: setUserPermissions
-      summary: Set a users permissions
+      summary: Set a user's permissions
       description: >
-        Updates a users permissions.
+        Updates a user's permissions.
         Permissions omitted in the request will be dropped if owned by the user previously.
         The update will reach the user, when he updates his JWT token.
       parameters:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -919,7 +919,7 @@ components:
         ALTER_SUGGESTIONS -> Enquing a song while holding this permission will give feedback to suggesters
         CHANGE_VOLUME -> Allows to change the playback volume;
         EXIT -> Allows sending a shutdown signal to the bot;
-        MANAGE_USERS -> Allows deleting or altering other users and their permissions;
+        ADMIN -> Allows deleting or altering other users and their permissions. Granting a user the admin permission will automatically grant him all other current permissions. Users holding the admin permission can not alter the permissions of other admins;
       enum:
         - skip
         - dislike
@@ -929,7 +929,7 @@ components:
         - alter_suggestions
         - change_volume
         - exit
-        - manage_users
+        - admin
 
   securitySchemes:
     Token:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -145,7 +145,7 @@ paths:
         404:
           description: The user does not exist
     delete:
-      operationId: deleteDifferentUser
+      operationId: deleteOtherUser
       summary: Deletes a selected user
       description: >
         Deletes the user defined in path
@@ -907,15 +907,15 @@ components:
         EXIT -> Allows sending a shutdown signal to the bot;
         USER -> Allows deleting or altering other users and their permissions;
       enum:
-        - SKIP
-        - DISLIKE
-        - MOVE
-        - PAUSE
-        - ENQUEUE
-        - ALTER_SUGGESTIONS
-        - CHANGE_VOLUME
-        - EXIT
-        - USER
+        - skip
+        - dislike
+        - move
+        - pause
+        - enqueue
+        - alter_suggestions
+        - change_volume
+        - exit
+        - user
 
   securitySchemes:
     Token:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -161,7 +161,7 @@ paths:
           description: The user to delete
           required: true
       responses:
-        201:
+        204:
           description: The deletion was successful
         401:
           $ref: "#/components/responses/Unauthenticated"
@@ -195,7 +195,7 @@ paths:
               items:
                 $ref: '#/components/schemas/Permission'
       responses:
-        201:
+        204:
           description: The update was successful
         401:
           $ref: "#/components/responses/Unauthenticated"
@@ -929,8 +929,8 @@ components:
         CHANGE_VOLUME -> Allows to change the playback volume;
         EXIT -> Allows sending a shutdown signal to the bot;
         ADMIN -> Allows deleting or altering other users and their permissions.
-          Granting a user the admin permission will automatically grant him all other current permissions.
-          Users holding the admin permission can not alter the permissions of other admins;
+          Granting a user the admin permission will automatically grant him all other current permissions except OWNER.
+          Users holding the admin permission can not alter the permissions of or delete other admins;
         OWNER -> Allows altering permissions or deleting users holding the ADMIN or OWNER permission.
       enum:
         - skip

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -123,7 +123,8 @@ paths:
       summary: Retrieves information about a user
       description: >
         Returns information about the user specified in the path.
-        Permission information about the user reflects the current state of the bot, permissions saved in still valid JWT tokens may vary.
+        Permission information about the user reflects the current state of the bot,
+        permissions saved in still valid JWT tokens may vary.
       parameters:
         - name: username
           in: path
@@ -202,7 +203,8 @@ paths:
       summary: Retrieve all users
       description: >
         Retrieves information about all full users.
-        Permission information about users reflects the current state of the bot, permissions saved in still valid JWT tokens may vary.
+        Permission information about users reflects the current state of the bot,
+        permissions saved in still valid JWT tokens may vary.
       responses:
         200:
           description: A list of user information
@@ -911,7 +913,8 @@ components:
     Permission:
       type: string
       description: >
-        SKIP -> The permission to skip the current song or remove songs from the queue. Note that a user is always allowed to remove a song from the queue which he added himself.;
+        SKIP -> The permission to skip the current song or remove songs from the queue.
+          Note that a user is always allowed to remove a song from the queue which he added himself.;
         DISLIKE -> The permission to remove songs from the upcoming suggestions of a suggester;
         MOVE -> Users with this permission can alter the queue order;
         PAUSE -> Allows pausing/resuming the playback;
@@ -919,7 +922,9 @@ components:
         ALTER_SUGGESTIONS -> Enquing a song while holding this permission will give feedback to suggesters
         CHANGE_VOLUME -> Allows to change the playback volume;
         EXIT -> Allows sending a shutdown signal to the bot;
-        ADMIN -> Allows deleting or altering other users and their permissions. Granting a user the admin permission will automatically grant him all other current permissions. Users holding the admin permission can not alter the permissions of other admins;
+        ADMIN -> Allows deleting or altering other users and their permissions.
+          Granting a user the admin permission will automatically grant him all other current permissions.
+          Users holding the admin permission can not alter the permissions of other admins;
       enum:
         - skip
         - dislike

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -117,6 +117,104 @@ paths:
           $ref: "#/components/responses/Unauthenticated"
         403:
           $ref: "#/components/responses/Unauthorized"
+  "/user/{username}":
+    get:
+      operationId: getUser
+      summary: Retrieves information about a user
+      description: >
+        Returns information about the user specified in the path.
+        Permission information about the user reflects the current state of the bot, permissions saved in still valid JWT tokens may vary.
+      parameters:
+        - name: username
+          in: path
+          schema:
+            type: string
+          description: The user to retrieve
+          required: true
+      responses:
+        200:
+          description: Information about the user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfo"
+        401:
+          $ref: "#/components/responses/Unauthenticated"
+        403:
+          $ref: "#/components/responses/Unauthorized"
+        404:
+          description: The user does not exist
+    put:
+      operationId: setUserPermissions
+      summary: Set a users permissions
+      description: >
+        Updates a users permissions.
+        Permissions omitted in the request will be dropped if owned by the user previously.
+        The update will reach the user, when he updates his JWT token.
+      parameters:
+        - name: username
+          in: path
+          schema:
+            type: string
+          description: The user to update
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Permission'
+      responses:
+        201:
+          description: The update was successful
+        401:
+          $ref: "#/components/responses/Unauthenticated"
+        403:
+          $ref: "#/components/responses/Unauthorized"
+        404:
+          description: The user does not exist
+    delete:
+      operationId: deleteDifferentUser
+      summary: Deletes a selected user
+      description: >
+        Deletes the user defined in path
+      parameters:
+        - name: username
+          in: path
+          schema:
+            type: string
+          description: The user to delete
+          required: true
+      responses:
+        201:
+          description: The deletion was successful
+        401:
+          $ref: "#/components/responses/Unauthenticated"
+        403:
+          $ref: "#/components/responses/Unauthorized"
+        404:
+          description: The user does not exist
+  /users:
+    get:
+      operationId: getUsers
+      summary: Retrieve all users
+      description: >
+        Retrieves information about all full users.
+        Permission information about users reflects the current state of the bot, permissions saved in still valid jwt tokens may vary.
+      responses:
+        200:
+          description: A list of user information
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                    $ref: '#/components/schemas/UserInfo'
+        401:
+          $ref: "#/components/responses/Unauthenticated"
+        403:
+          $ref: "#/components/responses/Unauthorized"
   /token:
     get:
       operationId: loginUser
@@ -806,6 +904,7 @@ components:
         ALTER_SUGGESTIONS -> Enquing a song while holding this permission will give feedback to suggesters
         CHANGE_VOLUME -> Allows to change the playback volume;
         EXIT -> Allows sending a shutdown signal to the bot;
+        USER -> Allows deleting or altering other users and their permissions;
       enum:
         - SKIP
         - DISLIKE
@@ -815,6 +914,7 @@ components:
         - ALTER_SUGGESTIONS
         - CHANGE_VOLUME
         - EXIT
+        - USER
 
   securitySchemes:
     Token:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -202,7 +202,7 @@ paths:
       summary: Retrieve all users
       description: >
         Retrieves information about all full users.
-        Permission information about users reflects the current state of the bot, permissions saved in still valid jwt tokens may vary.
+        Permission information about users reflects the current state of the bot, permissions saved in still valid JWT tokens may vary.
       responses:
         200:
           description: A list of user information

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -716,7 +716,7 @@ components:
           description: A list of permission identifiers for this user.
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/Permission'
     RegisterCredentials:
       type: object
       required:
@@ -795,6 +795,26 @@ components:
         refreshToken:
           description: A long-lived opaque token to refresh the access token.
           type: string
+    Permission:
+      type: string
+      description: >
+        SKIP -> Allows skipping songs;
+        DISLIKE -> Allows removing a song suggestion;
+        MOVE -> Users with this permission can alter the queue order;
+        PAUSE -> Allows pausing the playback;
+        ENQUEUE -> Allows enquing songs;
+        ALTER_SUGGESTIONS -> Enquing a song while holding this permission will give feedback to suggesters
+        CHANGE_VOLUME -> Allows to change the playback volume;
+        EXIT -> Allows sending a shutdown signal to the bot;
+      enum:
+        - SKIP
+        - DISLIKE
+        - MOVE
+        - PAUSE
+        - ENQUEUE
+        - ALTER_SUGGESTIONS
+        - CHANGE_VOLUME
+        - EXIT
 
   securitySchemes:
     Token:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -931,7 +931,7 @@ components:
         ADMIN -> Allows deleting or altering other users (except OWNERs) and their permissions.
           Granting a user the admin permission will automatically grant him all other current permissions except OWNER.
           Users holding the admin permission can not alter the permissions of or delete other admins;
-        OWNER -> Allows altering permissions or deleting users holding the ADMIN or OWNER permission.
+        OWNER -> Allows granting the ADMIN permission, altering permissions of admins and owners or deleting ADMIN or OWNER users.
       enum:
         - skip
         - dislike

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -905,7 +905,7 @@ components:
         ALTER_SUGGESTIONS -> Enquing a song while holding this permission will give feedback to suggesters
         CHANGE_VOLUME -> Allows to change the playback volume;
         EXIT -> Allows sending a shutdown signal to the bot;
-        USER -> Allows deleting or altering other users and their permissions;
+        MANAGE_USERS -> Allows deleting or altering other users and their permissions;
       enum:
         - skip
         - dislike
@@ -915,7 +915,7 @@ components:
         - alter_suggestions
         - change_volume
         - exit
-        - user
+        - manage_users
 
   securitySchemes:
     Token:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -931,7 +931,8 @@ components:
         ADMIN -> Allows deleting or altering other users (except OWNERs) and their permissions.
           Granting a user the admin permission will automatically grant him all other current permissions except OWNER.
           Users holding the admin permission can not alter the permissions of or delete other admins;
-        OWNER -> Allows granting the ADMIN permission, altering permissions of admins and owners or deleting ADMIN or OWNER users.
+        OWNER -> Allows granting the ADMIN permission, altering permissions of admins and owners or
+          deleting ADMIN or OWNER users.
       enum:
         - skip
         - dislike

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -144,14 +144,35 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         404:
           description: The user does not exist
-  "/user/{username}/permission"
+    delete:
+      operationId: deleteDifferentUser
+      summary: Deletes a selected user
+      description: >
+        Deletes the user defined in path
+      parameters:
+        - name: username
+          in: path
+          schema:
+            type: string
+          description: The user to delete
+          required: true
+      responses:
+        201:
+          description: The deletion was successful
+        401:
+          $ref: "#/components/responses/Unauthenticated"
+        403:
+          $ref: "#/components/responses/Unauthorized"
+        404:
+          description: The user does not exist
+  "/user/{username}/permission":
     put:
       operationId: setUserPermissions
       summary: Set a user's permissions
       description: >
         Updates a user's permissions.
         Permissions omitted in the request will be dropped if owned by the user previously.
-        The update will reach the user, when he updates his JWT token.
+        The update will reach the user when he updates his JWT token.
       parameters:
         - name: username
           in: path
@@ -169,27 +190,6 @@ paths:
       responses:
         201:
           description: The update was successful
-        401:
-          $ref: "#/components/responses/Unauthenticated"
-        403:
-          $ref: "#/components/responses/Unauthorized"
-        404:
-          description: The user does not exist
-    delete:
-      operationId: deleteDifferentUser
-      summary: Deletes a selected user
-      description: >
-        Deletes the user defined in path
-      parameters:
-        - name: username
-          in: path
-          schema:
-            type: string
-          description: The user to delete
-          required: true
-      responses:
-        201:
-          description: The deletion was successful
         401:
           $ref: "#/components/responses/Unauthenticated"
         403:

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -928,7 +928,7 @@ components:
         ALTER_SUGGESTIONS -> Enquing a song while holding this permission will give feedback to suggesters
         CHANGE_VOLUME -> Allows to change the playback volume;
         EXIT -> Allows sending a shutdown signal to the bot;
-        ADMIN -> Allows deleting or altering other users and their permissions.
+        ADMIN -> Allows deleting or altering other users (except OWNERs) and their permissions.
           Granting a user the admin permission will automatically grant him all other current permissions except OWNER.
           Users holding the admin permission can not alter the permissions of or delete other admins;
         OWNER -> Allows altering permissions or deleting users holding the ADMIN or OWNER permission.

--- a/MusicBot.yaml
+++ b/MusicBot.yaml
@@ -129,7 +129,7 @@ paths:
           in: path
           schema:
             type: string
-          description: The user to retrieve
+          description: The user to retrieve. Usernames are case-insensitive
           required: true
       responses:
         200:
@@ -144,6 +144,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         404:
           description: The user does not exist
+  "/user/{username}/permission"
     put:
       operationId: setUserPermissions
       summary: Set a user's permissions
@@ -156,7 +157,7 @@ paths:
           in: path
           schema:
             type: string
-          description: The user to update
+          description: The user to update. Usernames are case-insensitive
           required: true
       requestBody:
         content:
@@ -896,11 +897,11 @@ components:
     Permission:
       type: string
       description: >
-        SKIP -> Allows skipping songs;
-        DISLIKE -> Allows removing a song suggestion;
+        SKIP -> The permission to skip the current song or remove songs from the queue. Note that a user is always allowed to remove a song from the queue which he added himself.;
+        DISLIKE -> The permission to remove songs from the upcoming suggestions of a suggester;
         MOVE -> Users with this permission can alter the queue order;
-        PAUSE -> Allows pausing the playback;
-        ENQUEUE -> Allows enquing songs;
+        PAUSE -> Allows pausing/resuming the playback;
+        ENQUEUE -> Allows enqueueing songs;
         ALTER_SUGGESTIONS -> Enquing a song while holding this permission will give feedback to suggesters
         CHANGE_VOLUME -> Allows to change the playback volume;
         EXIT -> Allows sending a shutdown signal to the bot;


### PR DESCRIPTION
Adds user and permission management (#21)

I am personally unhappy with  `operationId: deleteDifferentUser`, but I don't want to break existing implementations by renaming `deleteUser`.